### PR TITLE
Removed build.sh

### DIFF
--- a/Cakebrew.xcodeproj/project.pbxproj
+++ b/Cakebrew.xcodeproj/project.pbxproj
@@ -334,7 +334,6 @@
 				1FE4FE51148E4CDD008EDE8B /* Frameworks */,
 				1FE4FE52148E4CDD008EDE8B /* Resources */,
 				1570BA6018EF9B0F001C3C5C /* CopyFiles */,
-				153AD45918F4A45E000D6FB5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -409,22 +408,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		153AD45918F4A45E000D6FB5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"/Users/bruno/Workspace/Release Apps/Cakebrew/Cakebrew/BumpBuild.sh\" \"${PROJECT_DIR}/${INFOPLIST_FILE}\"";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		1FE4FE50148E4CDD008EDE8B /* Sources */ = {


### PR DESCRIPTION
The build path to your bumpVersion is hard coded in the shell phase which causes an error if you are compiling it from the source, because e.g. my xcode project is not in a folder named "workspace". 
