### PR TITLE
#18 UI freezes while updating homebrew formulas or packages

### DIFF
--- a/Cakebrew/BPHomebrewManager.m
+++ b/Cakebrew/BPHomebrewManager.m
@@ -50,17 +50,19 @@
 
 - (void)update
 {
-	[self setFormulas_installed:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_INSTALLED]];
-	[self setFormulas_leaves:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_LEAVES]];
-	[self setFormulas_outdated:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_UPGRADEABLE]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self setFormulas_installed:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_INSTALLED]];
+        [self setFormulas_leaves:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_LEAVES]];
+        [self setFormulas_outdated:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_UPGRADEABLE]];
 
-	if (![self loadAllFormulasCaches]) {
-		dispatch_async(dispatch_get_main_queue(), ^{
+        if (![self loadAllFormulasCaches]) {
+
 			[self setFormulas_all:[[BPHomebrewInterface sharedInterface] listMode:kBP_LIST_ALL]];
 			[self storeAllFormulasCaches];
 			[self.delegate homebrewManagerFinishedUpdating:self];
-		});
-	}
+            
+        }
+    });
 }
 
 /**

--- a/Cakebrew/BPUpdateDoctorController.m
+++ b/Cakebrew/BPUpdateDoctorController.m
@@ -75,12 +75,15 @@
 	[self.textView_update setString:@""];
 	[self.button_update_runStop setEnabled:NO];
 	[self.progress_update startAnimation:sender];
-	NSBlockOperation *block = [NSBlockOperation blockOperationWithBlock:^{
-		NSString *output = [[BPHomebrewInterface sharedInterface] update];
-		[self.textView_update setString:output];
-		[self.progress_update stopAnimation:sender];
-		[self.button_update_runStop setEnabled:YES];
-	}];
-	[block performSelector:@selector(start) withObject:nil afterDelay:0.1];
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        __block NSString *output = [[BPHomebrewInterface sharedInterface] update];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.textView_update setString:output];
+            [self.progress_update stopAnimation:sender];
+            [self.button_update_runStop setEnabled:YES];
+        });
+    });
 }
 @end

--- a/Cakebrew/Cakebrew-Info.plist
+++ b/Cakebrew/Cakebrew-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>117</string>
+	<string>120</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Perhaps we can do it this way? So the BPHomebrewInterface has not to decide wether we run the code in the main or in a background thread.
