### PR TITLE
Fixed passed-by-value struct argument contains uninitialized data.

### DIFF
--- a/Cakebrew/Libraries/DMSplitView/DMSplitView.m
+++ b/Cakebrew/Libraries/DMSplitView/DMSplitView.m
@@ -675,6 +675,7 @@
         }];
 	} else {
         NSRect newRect[numberOfSubviews];
+        memset(newRect, 0, sizeof(newRect));
         [self getNewSubviewsRects:newRect withIndexes:indexes andPositions:newPositions];
         
         for (NSUInteger i = 0; i < numberOfSubviews; i++) {


### PR DESCRIPTION
As title. Please review, thanks.
