### PR TITLE
Ignore caveats line for dependencies.

### DIFF
--- a/Cakebrew/Models/BPFormula.m
+++ b/Cakebrew/Models/BPFormula.m
@@ -161,7 +161,7 @@
 	for (i=0; i<lines.count; i++) {
 		line = [lines objectAtIndex:lineIndex+i];
 
-		if (![line isEqualToString:@""] && ![line isEqualToString:@"==> Options"]) {
+		if (![line isEqualToString:@""] && ![line isEqualToString:@"==> Options"] && ![line isEqualToString:@"==> Caveats"]) {
 			if (self.dependencies) {
 				self.dependencies = [self.dependencies stringByAppendingFormat:@"; %@", line];
 			} else {


### PR DESCRIPTION
May the formula's dependencies ignore its caveats information? :confused:

![screen shot 2014-05-07 at 6 52 24 pm](https://cloud.githubusercontent.com/assets/291175/2900973/a1ffc2bc-d5ce-11e3-8693-9e840d6d6639.png)
