### PR TITLE
Hack to make Cakebrew ignore output from login shell scripts.

### DIFF
--- a/Cakebrew/BPHomebrewInterface.m
+++ b/Cakebrew/BPHomebrewInterface.m
@@ -23,6 +23,7 @@
 #import "BPFormula.h"
 
 #define kBP_EXEC_FILE_NOT_FOUND 32512
+NSString *const cakebrewOutputIdentifier = @"+++++Cakebrew+++++";
 
 @interface BPHomebrewInterfaceListCall : NSObject
 
@@ -235,7 +236,7 @@
 
 - (NSArray *)formatArgumentsForShell:(NSString *)shellName withExtraArguments:(NSArray *)extraArguments
 {
-	NSString *command = [NSString stringWithFormat:@"brew %@", [extraArguments componentsJoinedByString:@" "]];
+	NSString *command = [NSString stringWithFormat:@"echo \"%@\";brew %@", cakebrewOutputIdentifier, [extraArguments componentsJoinedByString:@" "]];
 	NSArray *arguments = @[@"-l", @"-c", command];
 
 	return arguments;
@@ -369,6 +370,8 @@
 	}
 
     NSString *string = [self performBrewCommandWithArguments:listCall.arguments];
+    string = [self removeLoginShellOutputFromResults:string];
+
     if (string) {
         return [listCall parseData:string];
 	} else {
@@ -387,7 +390,18 @@
 }
 
 - (NSString*)informationForFormula:(NSString*)formula {
-	return [self performBrewCommandWithArguments:@[@"info", formula]];
+	NSString *string = [self performBrewCommandWithArguments:@[@"info", formula]];
+    return [self removeLoginShellOutputFromResults:string];
+}
+
+- (NSString*)removeLoginShellOutputFromResults:(NSString*)results {
+    if (results) {
+        NSString *identifierWithEOL = [NSString stringWithFormat:@"%@\n", cakebrewOutputIdentifier];
+        NSRange range = [results rangeOfString:identifierWithEOL];
+        return [results substringFromIndex:range.location + identifierWithEOL.length];
+    }
+    //If all else fails...
+    return nil;
 }
 
 - (NSString*)update __deprecated


### PR DESCRIPTION
Feel free to ignore this, but it's just one of many ideas on
how to solve this issue. ;)

Changed BPHomebrewInterface so that it wouldn't break if the
login shell wrote text to stdout before the command
(e.g. brew info) was actually run.

To accomplish this we just write a known constant string to
stdout before we run the command. Then, after the whole
thing is done running we can simply find that known string
and remove everything up to and including it, leaving us
with only the intended output of the command we ran.

This should also solve the issue reported in issue #59.
