### PR TITLE
fix untap button

### DIFF
--- a/Cakebrew/BPHomebrewViewController.m
+++ b/Cakebrew/BPHomebrewViewController.m
@@ -434,6 +434,7 @@ typedef NS_ENUM(NSUInteger, HomeBrewTab) {
 					[self prepareFormulae:@[formula] forOperation:kBPWindowOperationUntap withOptions:nil];
 				};
 			}
+        break;
 
 			case kBPWindowOperationTap:
 			{


### PR DESCRIPTION
lack of break statement was causing the untap button to instead execute the tap action
