### PR TITLE
Quit app when main window closes

### DIFF
--- a/Cakebrew/BPAppDelegate.m
+++ b/Cakebrew/BPAppDelegate.m
@@ -81,6 +81,10 @@ NSString *const kBP_HOMEBREW_WEBSITE = @"https://www.cakebrew.com";
 	return NSTerminateNow;
 }
 
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+	return YES;
+}
+
 - (void)cleanupTaskAlerts
 {
 	[[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];


### PR DESCRIPTION
This is very minor. Not sure if the current behaviour is intended, but I would prefer if Cakebrew quit entirely after I close the main window.

This PR simply enables that.