### PR TITLE
Translate all localizable strings to French (France)

### DIFF
--- a/Cakebrew.xcodeproj/project.pbxproj
+++ b/Cakebrew.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		D2C4278B1B8E055B001C1F80 /* BPDisabledView.m in Sources */ = {isa = PBXBuildFile; fileRef = D2C427881B8E055B001C1F80 /* BPDisabledView.m */; };
 		D2CC8CA71B90F04C00F763DF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CC8CA61B90F04C00F763DF /* Security.framework */; };
 		D2F732F119190B75002B2512 /* NSString+URLValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = D2F732F019190B75002B2512 /* NSString+URLValidation.m */; };
+		F752F5591C79875600C0DEFE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F752F55B1C79875600C0DEFE /* InfoPlist.strings */; };
+		F752F55E1C79875600C0DEFE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F752F5601C79875600C0DEFE /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -233,6 +235,21 @@
 		D2CC8CA61B90F04C00F763DF /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		D2F732EF19190B75002B2512 /* NSString+URLValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+URLValidation.h"; sourceTree = "<group>"; };
 		D2F732F019190B75002B2512 /* NSString+URLValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+URLValidation.m"; sourceTree = "<group>"; };
+		F752F54A1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Loading.strings; sourceTree = "<group>"; };
+		F752F54B1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPFormulaOptionsWindow.strings; sourceTree = "<group>"; };
+		F752F54C1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPSelectedFormula.strings; sourceTree = "<group>"; };
+		F752F54D1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPUpdateView.strings; sourceTree = "<group>"; };
+		F752F54E1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F752F54F1C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPInstallationWindow.strings; sourceTree = "<group>"; };
+		F752F5501C79875400C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F752F5511C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPFormulaPopoverView.strings; sourceTree = "<group>"; };
+		F752F5521C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		F752F5531C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Disabled.strings; sourceTree = "<group>"; };
+		F752F5541C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/DCOAboutWindow.strings; sourceTree = "<group>"; };
+		F752F5551C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPDoctorView.strings; sourceTree = "<group>"; };
+		F752F5561C79875500C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/BPBundleWindow.strings; sourceTree = "<group>"; };
+		F752F55A1C79875600C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F752F55F1C79875600C0DEFE /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -484,6 +501,8 @@
 		D261C9C21B852FA300409803 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				F752F5601C79875600C0DEFE /* Localizable.strings */,
+				F752F55B1C79875600C0DEFE /* InfoPlist.strings */,
 				D261C9C31B852FA300409803 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -623,8 +642,10 @@
 				D2BBAB6D1B87142F00F21332 /* brewInfo_percona-server.txt in Resources */,
 				D2BBAB681B87142F00F21332 /* brewInfo_acme.txt in Resources */,
 				D2BBAB6A1B87142F00F21332 /* brewInfo_fakeformula.txt in Resources */,
+				F752F55E1C79875600C0DEFE /* Localizable.strings in Resources */,
 				D2BBAB6F1B87290B00F21332 /* brewInfo_bison.txt in Resources */,
 				D2BBAB711B87377D00F21332 /* brewInfo_sbtenv.txt in Resources */,
+				F752F5591C79875600C0DEFE /* InfoPlist.strings in Resources */,
 				D2BBAB6C1B87142F00F21332 /* brewInfo_mysql.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -710,6 +731,7 @@
 				15715F661C78D3C600AE0E66 /* en */,
 				15715F681C78D3C800AE0E66 /* pt */,
 				15715F6A1C78D3CC00AE0E66 /* de */,
+				F752F5561C79875500C0DEFE /* fr */,
 			);
 			name = BPBundleWindow.xib;
 			sourceTree = "<group>";
@@ -720,6 +742,7 @@
 				15D28A151AE332DB005C8A3E /* Base */,
 				15D28A371AE3433F005C8A3E /* pt */,
 				15A00B451B84072700528486 /* de */,
+				F752F5541C79875500C0DEFE /* fr */,
 			);
 			name = DCOAboutWindow.xib;
 			sourceTree = "<group>";
@@ -730,6 +753,7 @@
 				15D28A181AE332E6005C8A3E /* Base */,
 				15D28A381AE3433F005C8A3E /* pt */,
 				15A00B461B84072700528486 /* de */,
+				F752F5551C79875500C0DEFE /* fr */,
 			);
 			name = BPDoctorView.xib;
 			sourceTree = "<group>";
@@ -740,6 +764,7 @@
 				15D28A1B1AE332EA005C8A3E /* Base */,
 				15D28A391AE3433F005C8A3E /* pt */,
 				15A00B471B84072700528486 /* de */,
+				F752F54B1C79875400C0DEFE /* fr */,
 			);
 			name = BPFormulaOptionsWindow.xib;
 			sourceTree = "<group>";
@@ -750,6 +775,7 @@
 				15D28A1E1AE332EF005C8A3E /* Base */,
 				15D28A3A1AE3433F005C8A3E /* pt */,
 				15A00B481B84072700528486 /* de */,
+				F752F5511C79875500C0DEFE /* fr */,
 			);
 			name = BPFormulaPopoverView.xib;
 			sourceTree = "<group>";
@@ -760,6 +786,7 @@
 				15D28A211AE332F4005C8A3E /* Base */,
 				15D28A3B1AE3433F005C8A3E /* pt */,
 				15A00B491B84072700528486 /* de */,
+				F752F54F1C79875400C0DEFE /* fr */,
 			);
 			name = BPInstallationWindow.xib;
 			sourceTree = "<group>";
@@ -770,6 +797,7 @@
 				15D28A271AE332FD005C8A3E /* Base */,
 				150AEC571B3FA58D00163767 /* pt */,
 				15A00B4B1B84072700528486 /* de */,
+				F752F54C1C79875400C0DEFE /* fr */,
 			);
 			name = BPSelectedFormula.xib;
 			sourceTree = "<group>";
@@ -780,6 +808,7 @@
 				15D28A2A1AE33301005C8A3E /* Base */,
 				15D28A3E1AE34340005C8A3E /* pt */,
 				15A00B4C1B84072700528486 /* de */,
+				F752F54D1C79875400C0DEFE /* fr */,
 			);
 			name = BPUpdateView.xib;
 			sourceTree = "<group>";
@@ -790,6 +819,7 @@
 				15D28A331AE3433F005C8A3E /* pt */,
 				15A00B3E1B84003F00528486 /* en */,
 				15A00B421B84072700528486 /* de */,
+				F752F5501C79875400C0DEFE /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -800,6 +830,7 @@
 				15D28A341AE3433F005C8A3E /* pt */,
 				15A00B3D1B84002E00528486 /* en */,
 				15A00B431B84072700528486 /* de */,
+				F752F54E1C79875400C0DEFE /* fr */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -810,6 +841,7 @@
 				15D28A131AE332BC005C8A3E /* Base */,
 				15A00B3C1B84000600528486 /* pt */,
 				15A00B441B84072700528486 /* de */,
+				F752F5521C79875500C0DEFE /* fr */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";
@@ -820,6 +852,7 @@
 				D2C3E02B1B8E15B2000D89BB /* Base */,
 				D2C3E0351B8E15E2000D89BB /* pt */,
 				D2C3E0371B8E15E4000D89BB /* de */,
+				F752F5531C79875500C0DEFE /* fr */,
 			);
 			name = Disabled.xib;
 			path = Views;
@@ -831,9 +864,26 @@
 				D2C3E02E1B8E15D5000D89BB /* Base */,
 				D2C3E0311B8E15D7000D89BB /* pt */,
 				D2C3E0331B8E15DC000D89BB /* de */,
+				F752F54A1C79875400C0DEFE /* fr */,
 			);
 			name = Loading.xib;
 			path = Views;
+			sourceTree = "<group>";
+		};
+		F752F55B1C79875600C0DEFE /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F752F55A1C79875600C0DEFE /* fr */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		F752F5601C79875600C0DEFE /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F752F55F1C79875600C0DEFE /* fr */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -913,7 +963,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -938,7 +987,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Cakebrew/Cakebrew-Info.plist
+++ b/Cakebrew/Cakebrew-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>466</string>
+	<string>471</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Cakebrew/Libraries/DCOAboutWindow/fr.lproj/DCOAboutWindow.strings
+++ b/Cakebrew/Libraries/DCOAboutWindow/fr.lproj/DCOAboutWindow.strings
@@ -1,0 +1,15 @@
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "4ND-5E-RVg"; */
+"4ND-5E-RVg.title" = "Label";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "LaQ-kj-zXn"; */
+"LaQ-kj-zXn.title" = "Label";
+
+/* Class = "NSButtonCell"; title = "Acknowledgements"; ObjectID = "Wky-VX-jr0"; */
+"Wky-VX-jr0.title" = "Remerciements";
+
+/* Class = "NSButtonCell"; title = "Visit the %@ Website"; ObjectID = "eyI-Cm-PGX"; */
+"eyI-Cm-PGX.title" = "Visiter le site web de %@";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "wUa-DZ-OPf"; */
+"wUa-DZ-OPf.title" = "Label";
+

--- a/Cakebrew/Views/fr.lproj/Disabled.strings
+++ b/Cakebrew/Views/fr.lproj/Disabled.strings
@@ -1,0 +1,6 @@
+/* Class = "NSTextFieldCell"; title = "Homebrew is not installed"; ObjectID = "RHr-Q0-PYi"; */
+"RHr-Q0-PYi.title" = "Homebrew n'est pas installé";
+
+/* Class = "NSTextFieldCell"; title = "Please visit brew.sh to install Homebrew"; ObjectID = "sdR-dW-MDv"; */
+"sdR-dW-MDv.title" = "Veuillez vous rendre sur brew.sh pour installer Homebrew";
+

--- a/Cakebrew/Views/fr.lproj/Loading.strings
+++ b/Cakebrew/Views/fr.lproj/Loading.strings
@@ -1,0 +1,6 @@
+/* Class = "NSTextFieldCell"; title = "Loading..."; ObjectID = "O0A-7C-8R5"; */
+"O0A-7C-8R5.title" = "Chargement…";
+
+/* Class = "NSTextFieldCell"; title = "Loading"; ObjectID = "tg9-w7-WfT"; */
+"tg9-w7-WfT.title" = "Chargement";
+

--- a/Cakebrew/fr.lproj/BPBundleWindow.strings
+++ b/Cakebrew/fr.lproj/BPBundleWindow.strings
@@ -1,0 +1,24 @@
+/* Class = "NSTextFieldCell"; title = "Exporting File"; ObjectID = "Kyw-ca-xgs"; */
+"Kyw-ca-xgs.title" = "Exportation du fichier";
+
+/* Class = "NSTextFieldCell"; title = "Please wait while the file is imported."; ObjectID = "NRz-0t-Pn6"; */
+"NRz-0t-Pn6.title" = "Veuillez patienter pendant le chargement du fichier.";
+
+/* Class = "NSTextFieldCell"; title = "Homebrew Bundle"; ObjectID = "UHp-GH-2qP"; */
+"UHp-GH-2qP.title" = "Bundle Homebrew";
+
+/* Class = "NSTextFieldCell"; title = "Importing File"; ObjectID = "UQX-gO-pze"; */
+"UQX-gO-pze.title" = "Chargement du fichier";
+
+/* Class = "NSTextFieldCell"; title = "Please wait while the file is generated."; ObjectID = "Vid-Aa-KXl"; */
+"Vid-Aa-KXl.title" = "Veuillez patienter pendant la création du fichier.";
+
+/* Class = "NSWindow"; title = "Window"; ObjectID = "akb-99-UTb"; */
+"akb-99-UTb.title" = "Fenêtre";
+
+/* Class = "NSTextFieldCell"; title = "Export Successful"; ObjectID = "lO8-qv-x07"; */
+"lO8-qv-x07.title" = "Exportation réussie";
+
+/* Class = "NSButtonCell"; title = "Close"; ObjectID = "xSx-yq-DSQ"; */
+"xSx-yq-DSQ.title" = "Fermer";
+

--- a/Cakebrew/fr.lproj/BPDoctorView.strings
+++ b/Cakebrew/fr.lproj/BPDoctorView.strings
@@ -1,0 +1,9 @@
+/* Class = "NSButtonCell"; title = "Clear Log"; ObjectID = "AlR-6d-ju7"; */
+"AlR-6d-ju7.title" = "Effacer l'affichage";
+
+/* Class = "NSTextFieldCell"; title = "Homebrew Doctor"; ObjectID = "UHp-GH-2qP"; */
+"UHp-GH-2qP.title" = "Outil de diagnostique";
+
+/* Class = "NSButtonCell"; title = "Run Doctor"; ObjectID = "YyI-zq-THZ"; */
+"YyI-zq-THZ.title" = "Lancer le diagnostique";
+

--- a/Cakebrew/fr.lproj/BPFormulaOptionsWindow.strings
+++ b/Cakebrew/fr.lproj/BPFormulaOptionsWindow.strings
@@ -1,0 +1,24 @@
+/* Class = "NSTextFieldCell"; placeholderString = "Description for selected option."; ObjectID = "G5n-5T-DoK"; */
+"G5n-5T-DoK.placeholderString" = "Description de l'option sélectionnée";
+
+/* Class = "NSWindow"; title = "Window"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "Fenêtre";
+
+/* Class = "NSTextFieldCell"; title = "formula"; ObjectID = "XpC-iP-E4w"; */
+"XpC-iP-E4w.title" = "formule";
+
+/* Class = "NSTableColumn"; headerCell.title = "Options"; ObjectID = "XqV-53-e7D"; */
+"XqV-53-e7D.headerCell.title" = "Options";
+
+/* Class = "NSTextFieldCell"; title = "Text"; ObjectID = "YvH-f1-0Cw"; */
+"YvH-f1-0Cw.title" = "Texte";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "dCD-PS-P4J"; */
+"dCD-PS-P4J.title" = "Annuler";
+
+/* Class = "NSButtonCell"; title = "Install"; ObjectID = "hgj-Zo-s73"; */
+"hgj-Zo-s73.title" = "Installer";
+
+/* Class = "NSTextFieldCell"; title = "Picking Options for Formula:"; ObjectID = "idS-tT-jie"; */
+"idS-tT-jie.title" = "Options pour la formule :";
+

--- a/Cakebrew/fr.lproj/BPFormulaPopoverView.strings
+++ b/Cakebrew/fr.lproj/BPFormulaPopoverView.strings
@@ -1,0 +1,3 @@
+/* Class = "NSTextFieldCell"; title = "Information"; ObjectID = "wJR-yK-fGq"; */
+"wJR-yK-fGq.title" = "Information";
+

--- a/Cakebrew/fr.lproj/BPInstallationWindow.strings
+++ b/Cakebrew/fr.lproj/BPInstallationWindow.strings
@@ -1,0 +1,12 @@
+/* Class = "NSTextFieldCell"; title = "formula"; ObjectID = "L1M-vW-tCK"; */
+"L1M-vW-tCK.title" = "formule";
+
+/* Class = "NSTextFieldCell"; title = "Uninstalling Formula:"; ObjectID = "P2p-fh-Ixz"; */
+"P2p-fh-Ixz.title" = "Désinstaller la formule :";
+
+/* Class = "NSWindow"; title = "Window"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "Fenêtre";
+
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "atZ-M7-fU1"; */
+"atZ-M7-fU1.title" = "Ok";
+

--- a/Cakebrew/fr.lproj/BPSelectedFormula.strings
+++ b/Cakebrew/fr.lproj/BPSelectedFormula.strings
@@ -1,0 +1,33 @@
+/* Class = "NSTextFieldCell"; title = "Version:"; ObjectID = "0oO-wP-SOX"; */
+"0oO-wP-SOX.title" = "Version :";
+
+/* Class = "NSTextFieldCell"; title = "Formula not Installed"; ObjectID = "6S8-2E-jvV"; */
+"6S8-2E-jvV.title" = "Formule non installée";
+
+/* Class = "NSTextFieldCell"; title = "1.0 (stable)"; ObjectID = "9td-Re-cMi"; */
+"9td-Re-cMi.title" = "1.0 (stable)";
+
+/* Class = "NSTextFieldCell"; title = "Selected Formula Information"; ObjectID = "F2k-Nm-vhK"; */
+"F2k-Nm-vhK.title" = "Informations de la formule sélectionnée";
+
+/* Class = "NSTextFieldCell"; title = "Location:"; ObjectID = "Vpa-gA-Haq"; */
+"Vpa-gA-Haq.title" = "Emplacement :";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "hRD-g3-BCH"; */
+"hRD-g3-BCH.title" = "Aucun";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "iSv-34-44i"; */
+"iSv-34-44i.title" = "Aucun";
+
+/* Class = "NSTextFieldCell"; title = "Conflicts:"; ObjectID = "jTd-ja-Dck"; */
+"jTd-ja-Dck.title" = "Conflits :";
+
+/* Class = "NSTextFieldCell"; title = "No description provided"; ObjectID = "tcI-5w-fqk"; */
+"tcI-5w-fqk.title" = "Pas de description";
+
+/* Class = "NSTextFieldCell"; title = "Dependencies:"; ObjectID = "v3f-Nd-iQs"; */
+"v3f-Nd-iQs.title" = "Prérequis :";
+
+/* Class = "NSTextFieldCell"; title = "Description:"; ObjectID = "y6Q-3P-Z8p"; */
+"y6Q-3P-Z8p.title" = "Description :";
+

--- a/Cakebrew/fr.lproj/BPUpdateView.strings
+++ b/Cakebrew/fr.lproj/BPUpdateView.strings
@@ -1,0 +1,9 @@
+/* Class = "NSButtonCell"; title = "Clear Log"; ObjectID = "EE6-5g-Jos"; */
+"EE6-5g-Jos.title" = "Effacer l'affichage";
+
+/* Class = "NSButtonCell"; title = "Update Homebrew"; ObjectID = "MVF-cn-lfW"; */
+"MVF-cn-lfW.title" = "Mettre à jour Homebrew";
+
+/* Class = "NSTextFieldCell"; title = "You should update homebrew at least once every 24 hours."; ObjectID = "xJf-gA-oo0"; */
+"xJf-gA-oo0.title" = "Il est recommandé de mettre à jour Homebrew au moins une fois par jour.";
+

--- a/Cakebrew/fr.lproj/InfoPlist.strings
+++ b/Cakebrew/fr.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* (No Commment) */
+"CFBundleName" = "Cakebrew";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.2";
+
+/* (No Commment) */
+"NSHumanReadableCopyright" = "Copyright © 2014-2016 Bruno Philip. Tous droits réservés.";
+

--- a/Cakebrew/fr.lproj/Localizable.strings
+++ b/Cakebrew/fr.lproj/Localizable.strings
@@ -1,0 +1,243 @@
+/* No comment provided by engineer. */
+"Cakebrew" = "Cakebrew";
+
+/* No comment provided by engineer. */
+"Confirmation_Install_Formula" = "Êtes-vous sûr de vouloir installer la formule « %@ » ?";
+
+/* (No Commment) */
+"Confirmation_Tap_Repo" = "Êtes-vous sûr de vouloir ajouter le dépôt « %@ » ?";
+
+/* No comment provided by engineer. */
+"Confirmation_Uninstall_Formula" = "Êtes-vous sûr de vouloir désinstaller la formule « %@ » ?";
+
+/* (No Commment) */
+"Confirmation_Untap_Repo" = "Êtes-vous sûr de vouloir supprimer le dépôt « %@ » ?";
+
+/* (No Commment) */
+"Confirmation_Update_Formula" = "Êtes-vous sûr de vouloir mettre à jour ces formules ?";
+
+/* No comment provided by engineer. */
+"Formula_Options_ClickForDetails" = "Sélectionnez une option pour voir plus de détails.";
+
+/* No comment provided by engineer. */
+"Formula_Options_Confirmation" = "Êtes-vous sûr de vouloir installer la formule « %@ » avec les options sélectionnées ?";
+
+/* No comment provided by engineer. */
+"Formula_Options_NoOptions" = "Cette formule n'a pas d'options.";
+
+/* No comment provided by engineer. */
+"Formula_Options_VoiceOver" = "Options de la formule";
+
+/* No comment provided by engineer. */
+"Formula_Options_VoiceOver_Description" = "Les descriptions d'options sont aussi accessibles via l'aide VoiceOver pour chaque ligne de la liste d'options.";
+
+/* (No Commment) */
+"Formula_Popover_Error" = "Une erreur est survenue en essayant de retrouver les informations de cette formule";
+
+/* No comment provided by engineer. */
+"Formula_Popover_Title" = "Informations pour la formule : %@";
+
+/* No comment provided by engineer. */
+"Formula_Status_Installed" = "Installée";
+
+/* No comment provided by engineer. */
+"Formula_Status_Not_Installed" = "Non installée";
+
+/* No comment provided by engineer. */
+"Formula_Status_Outdated" = "Mise à jour disponible";
+
+/* No comment provided by engineer. */
+"Formulae" = "Formules";
+
+/* No comment provided by engineer. */
+"Generic_Attention" = "Attention !";
+
+/* No comment provided by engineer. */
+"Generic_Cancel" = "Annuler";
+
+/* No comment provided by engineer. */
+"Generic_Error" = "Erreur";
+
+/* (No Commment) */
+"Generic_No" = "Non";
+
+/* No comment provided by engineer. */
+"Generic_OK" = "Ok";
+
+/* No comment provided by engineer. */
+"Generic_Yes" = "Oui";
+
+/* No comment provided by engineer. */
+"Homebrew_AppNap_Task_Reason" = "Exécuter une tâche avec Homebrew";
+
+/* No comment provided by engineer. */
+"Homebrew_Task_Finished" = "Tâche terminée";
+
+/* No comment provided by engineer. */
+"Homebrew_Task_Finished_At" = "à";
+
+/* No comment provided by engineer. */
+"Info_View_Formula_No_Conflicts" = "Cette formule n'a pas de conflits connus.";
+
+/* No comment provided by engineer. */
+"Info_View_Formula_No_Dependencies" = "Cette formule n'a pas de prérequis !";
+
+/* No comment provided by engineer. */
+"Info_View_Formula_No_Description" = "Pas de description.";
+
+/* No comment provided by engineer. */
+"Info_View_Formula_Not_Installed" = "Formule non installée.";
+
+/* No comment provided by engineer. */
+"Info_View_Multiple_Values" = "Plusieurs valeurs";
+
+/* No comment provided by engineer. */
+"Installation_Window_All_Formulae" = "Toutes les formules en attente de mise à jour";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Cleanup" = "Nettoyage en cours…";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Install" = "Installation en cours de la formule :";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Tap" = "Ajout en cours du dépôt :";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Uninstall" = "Désinstallation en cours de la formule :";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Untap" = "Suppression en cours du dépôt :";
+
+/* No comment provided by engineer. */
+"Installation_Window_Operation_Update" = "Mise à jour en cours de la formule :";
+
+/* No comment provided by engineer. */
+"Message_BGTask_Body" = "Désolé, une tâche de fond est déjà en cours d'exécution. Vous ne pouvez pas exécuter deux tâches en même temps.";
+
+/* No comment provided by engineer. */
+"Message_BGTask_Title" = "Tâche de fond active !";
+
+/* No comment provided by engineer. */
+"Message_No_Homebrew_Body" = "Homebrew n'est pas présent sur votre système. Veuillez installer Homebrew avant d'utiliser Cakebrew. Vous pouvez cliquer sur le bouton ci-dessous pour aller sur le site web de Homebrew.";
+
+/* No comment provided by engineer. */
+"Message_No_Homebrew_Title" = "Site web de Homebrew";
+
+/* No comment provided by engineer. */
+"Message_Shell_Invalid_Body" = "Veuillez ajouter votre shell « %@ » dans le fichier des shells valides à « /etc/shells » et essayez à nouveau.";
+
+/* No comment provided by engineer. */
+"Message_Shell_Invalid_Title" = "Aucun shell valide n'a été trouvé !";
+
+/* No comment provided by engineer. */
+"Message_Tap_Body" = "Quel dépôt voulez-vous ajouter ?";
+
+/* No comment provided by engineer. */
+"Message_Tap_Title" = "Ajout en cours du dépôt";
+
+/* No comment provided by engineer. */
+"Message_Untap_Body" = "Êtes-vous sûr de vouloir supprimer le dépôt « %@ » ?";
+
+/* No comment provided by engineer. */
+"Message_Untap_Title" = "Suppression en cours du dépôt";
+
+/* No comment provided by engineer. */
+"Message_Update_All_Outdated_Body" = "Êtes-vous sûr de vouloir mettre à jour toutes les formules ?";
+
+/* No comment provided by engineer. */
+"Message_Update_All_Outdated_Title" = "Mettre à jour toutes les formules";
+
+/* No comment provided by engineer. */
+"Message_Update_Formulae_Body" = "Êtes-vous sûr de vouloir mettre à jour les formules : %@ ?";
+
+/* No comment provided by engineer. */
+"Message_Update_Formulae_Title" = "Mise à jour en cours des formules";
+
+/* (No Commment) */
+"Notification_Doctor" = "Outil de diagnostique";
+
+/* No comment provided by engineer. */
+"Notification_Update" = "Mettre à jour Homebrew";
+
+/* No comment provided by engineer. */
+"Sidebar_Group_Formulae" = "Formules";
+
+/* No comment provided by engineer. */
+"Sidebar_Group_Tools" = "Outils";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_All" = "Formules disponibles avec Homebrew.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Doctor" = "L'outil de diagnostique permet de détecter les erreurs les plus fréquentes.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Installed" = "Formules déjà installées sur votre système.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Leaves" = "Formules qui ne sont utilisées par aucune autre formule.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Outdated" = "Formules déjà installées, mais une mise à jour est disponible.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Repos" = "Dépôts que vous avez ajoutés.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_SearchResults" = "Résultats de la recherche.";
+
+/* No comment provided by engineer. */
+"Sidebar_Info_Update" = "Mettre à jour Hombrew permet de mettre à jour les informations de toutes les formules disponibles.";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_All" = "Toutes les formules";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Doctor" = "Diagnostique";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Installed" = "Installées";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Leaves" = "Feuilles";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Outdated" = "En attente de mise à jour";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Repos" = "Dépôts";
+
+/* No comment provided by engineer. */
+"Sidebar_Item_Update" = "Mettre à jour";
+
+/* No comment provided by engineer. */
+"Sidebar_VoiceOver_Tools" = "Outils";
+
+/* No comment provided by engineer. */
+"Toolbar_Homebrew_Update" = "Mettre à jour Homebrew";
+
+/* No comment provided by engineer. */
+"Toolbar_Install_Formula" = "Installer une formule";
+
+/* No comment provided by engineer. */
+"Toolbar_More_Information" = "Plus d'informations";
+
+/* No comment provided by engineer. */
+"Toolbar_Search" = "Rechercher des formules";
+
+/* No comment provided by engineer. */
+"Toolbar_Tap_Repo" = "Ajouter un dépôt";
+
+/* No comment provided by engineer. */
+"Toolbar_Uninstall_Formula" = "Désinstaller une formule";
+
+/* No comment provided by engineer. */
+"Toolbar_Untap_Repo" = "Supprimer un dépôt";
+
+/* No comment provided by engineer. */
+"Toolbar_Update_Formula" = "Mettre à jour une formule";
+
+/* No comment provided by engineer. */
+"Toolbar_Update_Selected" = "Mettre à jour les formules sélectionnées";
+

--- a/Cakebrew/fr.lproj/MainMenu.strings
+++ b/Cakebrew/fr.lproj/MainMenu.strings
@@ -1,0 +1,336 @@
+/* Class = "NSMenuItem"; title = "Formula Website "; ObjectID = "0oV-it-p68"; */
+"0oV-it-p68.title" = "Site web de la formule";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "2Ce-cm-oqR"; */
+"2Ce-cm-oqR.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "2P3-U9-uO0"; */
+"2P3-U9-uO0.title" = "Copier/coller intelligent";
+
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "2Vq-Ue-Jgo"; */
+"2Vq-Ue-Jgo.title" = "Guillemets anglais";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "3gj-Tz-gwl"; */
+"3gj-Tz-gwl.title" = "Aller à la sélection";
+
+/* Class = "NSTextFieldCell"; title = "No selection"; ObjectID = "3xE-6a-fkA"; */
+"3xE-6a-fkA.title" = "Pas de sélection";
+
+/* Class = "NSMenuItem"; title = "Update Formula"; ObjectID = "4ab-Ns-Wry"; */
+"4ab-Ns-Wry.title" = "Mettre à jour la formule";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
+"5.title" = "Tout ramener au premier plan";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "5Ae-Ee-ok4"; */
+"5Ae-Ee-ok4.title" = "Transformations";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "5IY-wu-LBL"; */
+"5IY-wu-LBL.title" = "Couper";
+
+/* Class = "NSMenuItem"; title = "Update"; ObjectID = "8Vh-lk-gYe"; */
+"8Vh-lk-gYe.title" = "Mises à jour";
+
+/* Class = "NSMenuItem"; title = "Installed Formulae"; ObjectID = "8gP-gb-YtQ"; */
+"8gP-gb-YtQ.title" = "Formules installées";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "8wr-BZ-YYu"; */
+"8wr-BZ-YYu.title" = "Rechercher";
+
+/* Class = "NSMenuItem"; title = "Formula Website"; ObjectID = "9Fv-tF-1qy"; */
+"9Fv-tF-1qy.title" = "Site web de la formule";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "9Xg-s6-Icq"; */
+"9Xg-s6-Icq.title" = "Éditer";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "9hc-sq-AFZ"; */
+"9hc-sq-AFZ.title" = "Orthographe et grammaire";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "19"; */
+"19.title" = "Fenêtre";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "23"; */
+"23.title" = "Placer dans le Dock";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
+"24.title" = "Fenêtre";
+
+/* Class = "NSMenu"; title = "AMainMenu"; ObjectID = "29"; */
+"29.title" = "Menu principal";
+
+/* Class = "NSMenuItem"; title = "Cakebrew"; ObjectID = "56"; */
+"56.title" = "Cakebrew";
+
+/* Class = "NSMenu"; title = "Cakebrew"; ObjectID = "57"; */
+"57.title" = "Cakebrew";
+
+/* Class = "NSMenuItem"; title = "About Cakebrew"; ObjectID = "58"; */
+"58.title" = "À propos de Cakebrew";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "129"; */
+"129.title" = "Préférences…";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "130"; */
+"130.title" = "Services";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "131"; */
+"131.title" = "Services";
+
+/* Class = "NSMenuItem"; title = "Hide Cakebrew"; ObjectID = "134"; */
+"134.title" = "Masquer Cakebrew";
+
+/* Class = "NSMenuItem"; title = "Quit Cakebrew"; ObjectID = "136"; */
+"136.title" = "Quitter Cakebrew";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "145"; */
+"145.title" = "Masquer les autres";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "150"; */
+"150.title" = "Tout montrer";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "239"; */
+"239.title" = "Zoom";
+
+/* Class = "NSWindow"; title = "Cakebrew"; ObjectID = "371"; */
+"371.title" = "Cakebrew";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "490"; */
+"490.title" = "Aide";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "491"; */
+"491.title" = "Aide";
+
+/* Class = "NSMenuItem"; title = "Cakebrew Help"; ObjectID = "492"; */
+"492.title" = "Aide Cakebrew";
+
+/* Class = "NSViewController"; title = "HomebrewController"; ObjectID = "547"; */
+"547.title" = "HomebrewController";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "A78-TI-Q8X"; */
+"A78-TI-Q8X.headerCell.title" = "Nom";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "BFf-kE-eTe"; */
+"BFf-kE-eTe.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "BcF-eP-c6m"; */
+"BcF-eP-c6m.title" = "Remplacer le texte";
+
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "Bu5-tT-t6q"; */
+"Bu5-tT-t6q.title" = "Vérifier la grammaire et l'orthographe";
+
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "Clj-ps-Iag"; */
+"Clj-ps-Iag.title" = "Transformations";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "DNi-yY-5Ha"; */
+"DNi-yY-5Ha.title" = "Utiliser la sélection pour la recherche";
+
+/* Class = "NSMenuItem"; title = "Upgrade All Formulae"; ObjectID = "DdP-fd-ccO"; */
+"DdP-fd-ccO.title" = "Mettre à jour toutes les formules";
+
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "Dki-FU-69n"; */
+"Dki-FU-69n.title" = "Substitutions";
+
+/* Class = "NSMenuItem"; title = "Search for Formula"; ObjectID = "DpP-yi-xdi"; */
+"DpP-yi-xdi.title" = "Rechercher une formule";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "EBJ-Ce-8OO"; */
+"EBJ-Ce-8OO.title" = "Activer la fonctionnalité vocale";
+
+/* Class = "NSMenuItem"; title = "Upgrade Selected Formulae"; ObjectID = "Ep8-j6-m5Q"; */
+"Ep8-j6-m5Q.title" = "Installer les mises à jour pour les formules sélectionnée";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "Eud-wi-dvG"; */
+"Eud-wi-dvG.title" = "Fonction vocale";
+
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "GVv-as-Pfq"; */
+"GVv-as-Pfq.title" = "Mettre une majuscule";
+
+/* Class = "NSMenuItem"; title = "Export Brew Installation…"; ObjectID = "Gbv-K1-deL"; */
+"Gbv-K1-deL.title" = "Exporter collection de formules";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "H1C-ip-FlF"; */
+"H1C-ip-FlF.title" = "Annuler";
+
+/* Class = "NSMenuItem"; title = "Update Formula"; ObjectID = "Hhd-b7-GOc"; */
+"Hhd-b7-GOc.title" = "Installer la mise à jour pour la formule";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "J92-AZ-XUi"; */
+"J92-AZ-XUi.title" = "Rétablir";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "JPI-0A-NvM"; */
+"JPI-0A-NvM.title" = "Coller";
+
+/* Class = "NSTableColumn"; headerCell.title = "Status"; ObjectID = "JRi-Nr-5hA"; */
+"JRi-Nr-5hA.headerCell.title" = "État";
+
+/* Class = "NSMenuItem"; title = "Outdated Formulae"; ObjectID = "KUc-5l-twA"; */
+"KUc-5l-twA.title" = "Formules en attente de mise à jour";
+
+/* Class = "NSTextFieldCell"; title = "HEADER CELL"; ObjectID = "KoT-TI-MgQ"; */
+"KoT-TI-MgQ.title" = "HEADER CELL";
+
+/* Class = "NSMenuItem"; title = "Import Brew Installation…"; ObjectID = "LU8-D3-Wwe"; */
+"LU8-D3-Wwe.title" = "Importer collection de formules";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "LYP-iZ-WcV"; */
+"LYP-iZ-WcV.title" = "Éditer";
+
+/* Class = "NSMenuItem"; title = "Install Formula"; ObjectID = "Lcb-tm-ATo"; */
+"Lcb-tm-ATo.title" = "Installer la formule";
+
+/* Class = "NSMenuItem"; title = "Leaves"; ObjectID = "M9N-PI-gBO"; */
+"M9N-PI-gBO.title" = "Feuilles";
+
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "MQL-Vg-ECI"; */
+"MQL-Vg-ECI.title" = "Afficher les substitutions";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "MTR-Uj-kDH"; */
+"MTR-Uj-kDH.title" = "Tout sélectionner";
+
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "NlA-Cw-rt3"; */
+"NlA-Cw-rt3.title" = "Corriger automatiquement l'orthographe";
+
+/* Class = "NSMenuItem"; title = "Formula"; ObjectID = "NmF-5a-a6b"; */
+"NmF-5a-a6b.title" = "Formule";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "NrN-pe-J7E"; */
+"NrN-pe-J7E.title" = "Désactiver la fonctionnalité vocale";
+
+/* Class = "NSMenuItem"; title = "Brew Cleanup…"; ObjectID = "OKR-gG-lsa"; */
+"OKR-gG-lsa.title" = "Nettoyage…";
+
+/* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "OSn-ju-y85"; */
+"OSn-ju-y85.title" = "Rechercher et remplacer…";
+
+/* Class = "NSMenuItem"; title = "Uninstall Formula"; ObjectID = "Tzv-5t-RhL"; */
+"Tzv-5t-RhL.title" = "Désinstaller la formule";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "UBt-HC-zPr"; */
+"UBt-HC-zPr.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "UOm-zM-WGz"; */
+"UOm-zM-WGz.title" = "Vérifier l'orthographe pendant la saisie";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "UWA-Fh-fH5"; */
+"UWA-Fh-fH5.title" = "Rechercher le précédent";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "Uzy-PF-4ct"; */
+"Uzy-PF-4ct.title" = "Rechercher le suivant";
+
+/* Class = "NSMenuItem"; title = "Install Formula with Options..."; ObjectID = "Vio-Nc-WTc"; */
+"Vio-Nc-WTc.title" = "Installer la formule avec options…";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "VzS-XQ-BoP"; */
+"VzS-XQ-BoP.title" = "Text Cell";
+
+/* Class = "NSTabViewItem"; label = "Doctor"; ObjectID = "WM9-6z-Jzl"; */
+"WM9-6z-Jzl.label" = "Diagnostique";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "X7p-5G-5Dv"; */
+"X7p-5G-5Dv.title" = "Orthographe";
+
+/* Class = "NSMenuItem"; title = "Install Formula with Options…"; ObjectID = "X74-Yx-eRm"; */
+"X74-Yx-eRm.title" = "Installer la formule avec options…";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "XSL-d4-pFI"; */
+"XSL-d4-pFI.title" = "Copier";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "ZI1-yX-Bb1"; */
+"ZI1-yX-Bb1.title" = "Mettre en majuscules";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "ZNi-97-e1J"; */
+"ZNi-97-e1J.title" = "Présentation";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "Zen-la-cAG"; */
+"Zen-la-cAG.title" = "Fonction vocale";
+
+/* Class = "NSTabViewItem"; label = "Formulae"; ObjectID = "aFR-nx-bHM"; */
+"aFR-nx-bHM.label" = "Formules";
+
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "aQ6-GZ-1Wd"; */
+"aQ6-GZ-1Wd.title" = "Mettre en minuscules";
+
+/* Class = "NSMenuItem"; title = "Tools"; ObjectID = "b3s-t3-YFx"; */
+"b3s-t3-YFx.title" = "Outils";
+
+/* Class = "NSTableColumn"; headerCell.title = "Latest Version"; ObjectID = "ba4-r8-kgo"; */
+"ba4-r8-kgo.headerCell.title" = "Dernière version";
+
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "bv4-X8-jgK"; */
+"bv4-X8-jgK.title" = "Tirets intelligents";
+
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "cbL-gM-Pkc"; */
+"cbL-gM-Pkc.title" = "Afficher orthographe et grammaire";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "cdk-eL-aT2"; */
+"cdk-eL-aT2.title" = "Rechercher";
+
+/* Class = "NSMenuItem"; title = "Repositories"; ObjectID = "dXD-3s-NhA"; */
+"dXD-3s-NhA.title" = "Dépôts";
+
+/* Class = "NSMenu"; title = "Formula"; ObjectID = "dg5-kq-v1Y"; */
+"dg5-kq-v1Y.title" = "Formule";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "e0a-Xf-LW1"; */
+"e0a-Xf-LW1.title" = "Substitutions";
+
+/* Class = "NSMenuItem"; title = "Doctor"; ObjectID = "eI9-b4-Rmg"; */
+"eI9-b4-Rmg.title" = "Outil de diagnostique";
+
+/* Class = "NSMenuItem"; title = "More Information"; ObjectID = "eus-Jb-JjS"; */
+"eus-Jb-JjS.title" = "Plus d'informations";
+
+/* Class = "NSMenuItem"; title = "Install Formula"; ObjectID = "fhF-VX-squ"; */
+"fhF-VX-squ.title" = "Installer la formule";
+
+/* Class = "NSMenuItem"; title = "More Information"; ObjectID = "gxx-2S-F5T"; */
+"gxx-2S-F5T.title" = "Plus d'informations";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "h1A-B0-MNB"; */
+"h1A-B0-MNB.title" = "Supprimer";
+
+/* Class = "NSTableColumn"; headerCell.title = "Version"; ObjectID = "h5d-xc-Jih"; */
+"h5d-xc-Jih.headerCell.title" = "Version";
+
+/* Class = "NSMenuItem"; title = "Uninstall Formula"; ObjectID = "i3A-Nx-qPJ"; */
+"i3A-Nx-qPJ.title" = "Désinstaller la formule";
+
+/* Class = "NSMenu"; title = "Tools"; ObjectID = "lOM-6G-bAo"; */
+"lOM-6G-bAo.title" = "Outils";
+
+/* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "mB7-mH-abu"; */
+"mB7-mH-abu.title" = "Liens intelligents";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "mwc-hE-3i2"; */
+"mwc-hE-3i2.title" = "Présentation";
+
+/* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "oBx-PH-cgq"; */
+"oBx-PH-cgq.title" = "Détecteurs de donnée";
+
+/* Class = "NSMenu"; title = "Formula"; ObjectID = "sBH-Ta-Jft"; */
+"sBH-Ta-Jft.title" = "Formule";
+
+/* Class = "NSMenuItem"; title = "Visit Website"; ObjectID = "seZ-rp-Anf"; */
+"seZ-rp-Anf.title" = "Visiter le site web";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "uGY-87-ubc"; */
+"uGY-87-ubc.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "ugl-Oh-kYV"; */
+"ugl-Oh-kYV.title" = "Vérifiez le document maintenant";
+
+/* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "v4F-qE-2u0"; */
+"v4F-qE-2u0.title" = "Rechercher les mises à jour…";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "yCR-di-3ZT"; */
+"yCR-di-3ZT.title" = "Rechercher…";
+
+/* Class = "NSTabViewItem"; label = "Update"; ObjectID = "yL4-oW-nIm"; */
+"yL4-oW-nIm.label" = "Mises à jour";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "zVW-Ch-xYV"; */
+"zVW-Ch-xYV.title" = "Table View Cell";
+
+/* Class = "NSMenuItem"; title = "All Formulae"; ObjectID = "zam-2s-isx"; */
+"zam-2s-isx.title" = "Toutes les formules";
+

--- a/CakebrewTests/fr.lproj/InfoPlist.strings
+++ b/CakebrewTests/fr.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/* (No Commment) */
+"CFBundleName" = "Cakebrew";
+
+/* (No Commment) */
+"CFBundleShortVersionString" = "1.0";
+

--- a/CakebrewTests/fr.lproj/Localizable.strings
+++ b/CakebrewTests/fr.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+/* No comment provided by engineer. */
+"Generic_OK" = "Ok";
+
+/* No comment provided by engineer. */
+"Homebrew_AppNap_Task_Reason" = "Activer Homebrew en tâche de fond";
+
+/* No comment provided by engineer. */
+"Homebrew_Task_Finished" = "Tâche terminée";
+
+/* No comment provided by engineer. */
+"Homebrew_Task_Finished_At" = "à";
+
+/* No comment provided by engineer. */
+"Message_BGTask_Body" = "Désolé, une tâche de fond est déjà en cours d'exécution. Vous ne pouvez pas exécuter deux tâches en même temps.";
+
+/* No comment provided by engineer. */
+"Message_BGTask_Title" = "Tâche de fond active !";
+
+/* No comment provided by engineer. */
+"Message_Shell_Invalid_Body" = "Veuillez ajouter votre shell « %@ » dans le fichier des shells valides à « /etc/shells » et essayez à nouveau.";
+


### PR DESCRIPTION
### Comments by @bfontaine addressed:
* Formula -> "formule", comme sur la page d’accueil http://brew.sh. **Done**
* Formulae -> "formules", même raison. **Done**
* Proxy Settings -> "Réglages du proxy" plutôt que "Configuration du proxy" ?. **Proxy settings removed in newer version**
* http://:@: -> Pourquoi "http://<user>:<password>@<proxyhost>:<proxyport>" ? **Proxy settings removed in newer version**
* "Run Doctor" -> "Lancer le docteur" peut-être ? Trouver une formulation avec
"docteur" plutôt que "Diagnostique" permettrait d’éviter de mélanger les deux
termes pour la même chose. Ou alors on peut changer "Doctor" partout en
"Diagnostique" ou "Outil de diagnostique". **"Diagnostique" et "Outil de diagnostique"**
* "Pour plus d'information veuillez contacter" -> "Pour plus d’informations" ?. **Done**
* Update Homebrew -> "Mettre à jour Homebrew" plutôt que "Mise à jour" ?
  C’est plus long mais ça respecte plus l’original. **Done**
* "Il est recommandé de mettre à jour au moins …" -> Pourquoi avoir enlevé
"Homebrew" de la phrase ?. **Done**
* "Nettoyage..." -> "Nettoyage…" (alt+; sur le clavier azerty Mac pour faire "…")
  Même remarque pour "Installer la recette avec options...". **Done**
* "Latest Version" -> "Dernière version" plutôt que "Nouvelle version" ?. **Done**
* "Visit Website" -> "Visiter le site Web" plutôt que "Visiter le site internet" ?
  Même remarque que "Visiter le site internet de %@". **Done**
* "Homebrew Website" -> "Site Web d’Homebrew" plutôt que "Site internet de Homebrew" ?. **Done**
* "Êtes-vous sûr de vouloir installer la recette '%@' ?" et similaire, on
pourrait utiliser "… la recette « %@ » ?".. **Done**
* "Êtes-vous sûr de vouloir installer la recette '%@' avec ces options ?"
  plutôt "les options sélectionnées" pour calquer sur la version originale ?. **Done**
* "Tâche finie" -> "Tâche terminée" ?. **Done**
* "Homebrew n'est pas présent sur votre système. Veuillez installer Homebrew
avant d'utiliser Cakebrew. Vous pouvez cliquer sur le bouton ci-dess"
  Il manque la fin : "…ous pour afficher le site d’Homebrew". **Done**
* "Veuillez ajouter votre shell " -> il manque la fin :
  "à la liste des shells valides dans /etc/shells avant de réessayer.". **Done**

### Comments by @bfontaine NOT addressed:
* Un détail, mais dans "Plus d'informations" et similaires on peut utiliser
l’apostrophe typographique avec alt+shift+' sur l’azerty Mac.

Les traductions déjà proposées par Apple pour certains menu ne comportent pas cette apostrophe typographique mais l'apostrophe simple. Par soucis de cohérence et uniformité j'ai choisi de continuer avec l'apostrophe simple.
* "Leaves" -> "Feuilles"
  Je ne pense pas que "Feuilles" soit très compréhensible, mais c’est plus un
  défaut de la version originale que de la traduction. Il faudrait un mot ou
  une courte expression pour désigner les formules installées qui ne sont les
  dépendances d’aucune autre (donc qu’on peut désinstaller sans rien casser).

Je suis d'accord, mais je n'ai rien trouvé de mieux non plus... Étant donné que Cakebrew est un outil technique, j'imagine que les utilisateurs sauront ce qu'est une "feuille" dans le contexte d'un arbre (théorie des graphes).
* "Recettes disponibles avec Homebrew." et similaires
  -> "Voici les recettes disponibles avec Homebrew." plutôt ? L’original
  commence par "These are …", ce qui pourrait se traduire par "Voici les" si on
  veut rester court.

Étant donné que Cakebrew est un outil technique, je préfère rester succinct, la formulation "Voici la/le/les/ ..."  me semble un peu trop littéraire, qu'en penses tu ?

### While translating I found strings that, I believe, should not be accessible for localization:
* ${PRODUCT_NAME} x2
* 1.0
* 1.2
* HEADER CELL
* HomebrewController
* Label x3
* Menu principal
* Table View Cell
* Text Cell x4
@brunophilipe Please review these strings and let me know what I should do.

### Issues found when running the app with the french translation:
![screen shot 2016-02-21 at 5 03 25 pm](https://cloud.githubusercontent.com/assets/1822562/13201358/f94204b6-d8c1-11e5-8f62-10543427e334.png)
Wrong constraints on the label?

![screen shot 2016-02-21 at 5 03 33 pm](https://cloud.githubusercontent.com/assets/1822562/13201360/f99c1140-d8c1-11e5-8526-d50d24c3bd18.png)
Wrong constraints on the label?

![screen shot 2016-02-21 at 5 16 11 pm](https://cloud.githubusercontent.com/assets/1822562/13201359/f999c98a-d8c1-11e5-9672-15b235fd58d2.png)
I'm sure I translated this string, however it doesn't seem to be taken on that screen?

### Note
You can run the app in French without changing your computer's settings by adding:
`-AppleLanguages (fr)` in the **Arguments Passed On Launch** section of the **Arguments** tab of the **Run** section of the main scheme.

Thanks!