### PR TITLE
Display status as a coloured bullet in the first column

### DIFF
--- a/Cakebrew/BPFormulaeDataSource.m
+++ b/Cakebrew/BPFormulaeDataSource.m
@@ -122,19 +122,15 @@
 			if ([element isKindOfClass:[BPFormula class]]) {
 				switch ([[BPHomebrewManager sharedManager] statusForFormula:element]) {
 					case kBPFormulaInstalled:
-						return NSLocalizedString(@"Formula_Status_Installed", nil);
+						return [NSImage imageNamed:NSImageNameStatusAvailable];
             
 					case kBPFormulaNotInstalled:
-						return NSLocalizedString(@"Formula_Status_Not_Installed", nil);
+						return [NSImage imageNamed:NSImageNameStatusNone];
             
 					case kBPFormulaOutdated:
-						return NSLocalizedString(@"Formula_Status_Outdated", nil);
-            
-					default:
-						return @"";
+						return [NSImage imageNamed:NSImageNameStatusPartiallyAvailable];
+
 				}
-			} else {
-				return element;
 			}
 		}
   }

--- a/Cakebrew/BPFormulaeTableView.m
+++ b/Cakebrew/BPFormulaeTableView.m
@@ -41,6 +41,9 @@ unichar SPACE_CHARACTER = 0x0020;
 	
 	//OUR superview is NSClipView
 	totalWidth = [[self superview] frame].size.width;
+
+	// Reserve the space for status column
+	totalWidth -= 30.0;
 	
 	switch (self.mode) {
 		case kBPListAll:
@@ -48,7 +51,6 @@ unichar SPACE_CHARACTER = 0x0020;
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setHidden:YES];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setHidden:YES];
 			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:NO];
-			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setWidth:(totalWidth-titleWidth)*0.90];
 			[self setAllowsMultipleSelection:NO];
 			break;
 			
@@ -57,7 +59,7 @@ unichar SPACE_CHARACTER = 0x0020;
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setHidden:NO];
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setWidth:(totalWidth-titleWidth)*0.95];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setHidden:YES];
-			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:YES];
+			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:NO];
 			[self setAllowsMultipleSelection:NO];
 			break;
 			
@@ -65,7 +67,7 @@ unichar SPACE_CHARACTER = 0x0020;
 			titleWidth = (NSInteger)(totalWidth * 0.99);
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setHidden:YES];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setHidden:YES];
-			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:YES];
+			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:NO];
 			[self setAllowsMultipleSelection:NO];
 			break;
 			
@@ -75,7 +77,7 @@ unichar SPACE_CHARACTER = 0x0020;
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setWidth:(totalWidth-titleWidth)*0.48];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setHidden:NO];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setWidth:(totalWidth-titleWidth)*0.48];
-			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:YES];
+			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:NO];
 			[self setAllowsMultipleSelection:YES];
 			break;
 			
@@ -84,7 +86,6 @@ unichar SPACE_CHARACTER = 0x0020;
 			[[self tableColumnWithIdentifier:kColumnIdentifierVersion] setHidden:YES];
 			[[self tableColumnWithIdentifier:kColumnIdentifierLatestVersion] setHidden:YES];
 			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setHidden:NO];
-			[[self tableColumnWithIdentifier:kColumnIdentifierStatus] setWidth:(totalWidth-titleWidth)*0.90];
 			[self setAllowsMultipleSelection:NO];
 			break;
 			

--- a/Cakebrew/Base.lproj/MainMenu.xib
+++ b/Cakebrew/Base.lproj/MainMenu.xib
@@ -562,7 +562,7 @@ CA
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <rect key="contentRect" x="629" y="349" width="570" height="342"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <value key="minSize" type="size" width="570" height="342"/>
             <view key="contentView" id="372">
                 <rect key="frame" x="0.0" y="0.0" width="570" height="342"/>
@@ -589,16 +589,15 @@ CA
                                         <rect key="frame" x="0.0" y="0.0" width="190" height="322"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <subviews>
-                                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="kTq-kk-rF0">
+                                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="kTq-kk-rF0">
                                                 <rect key="frame" x="0.0" y="2" width="190" height="320"/>
                                                 <clipView key="contentView" drawsBackground="NO" id="RhN-kh-4Xx">
                                                     <rect key="frame" x="0.0" y="0.0" width="190" height="320"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="systemDefault" viewBased="YES" indentationPerLevel="16" outlineTableColumn="LEF-be-VWM" id="h1z-c9-U0s" customClass="PXSourceList">
+                                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="systemDefault" viewBased="YES" indentationPerLevel="16" outlineTableColumn="LEF-be-VWM" id="h1z-c9-U0s" customClass="PXSourceList">
                                                             <rect key="frame" x="0.0" y="0.0" width="190" height="0.0"/>
                                                             <autoresizingMask key="autoresizingMask"/>
-                                                            <size key="intercellSpacing" width="0.0" height="2"/>
                                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                             <tableColumns>
@@ -928,14 +927,23 @@ CA
                                 <rect key="frame" x="0.0" y="0.0" width="396" height="264"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" headerView="pLZ-e2-9bs" id="swO-GD-dpc" customClass="BPFormulaeTableView">
-                                        <rect key="frame" x="0.0" y="0.0" width="517" height="241"/>
+                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" headerView="pLZ-e2-9bs" id="swO-GD-dpc" customClass="BPFormulaeTableView">
+                                        <rect key="frame" x="0.0" y="0.0" width="402" height="241"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <size key="intercellSpacing" width="3" height="2"/>
                                         <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                         <tableColumns>
-                                            <tableColumn identifier="Name" editable="NO" width="160" minWidth="40" maxWidth="1000" id="A78-TI-Q8X">
+                                            <tableColumn identifier="Status" editable="NO" width="25" minWidth="25" maxWidth="25" id="JRi-Nr-5hA">
+                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="•">
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                </tableHeaderCell>
+                                                <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="f1d-6J-qPt"/>
+                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                            </tableColumn>
+                                            <tableColumn identifier="Name" editable="NO" width="135" minWidth="40" maxWidth="1000" id="A78-TI-Q8X">
                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
                                                     <font key="font" metaFont="smallSystem"/>
                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -946,7 +954,7 @@ CA
                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
-                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             </tableColumn>
                                             <tableColumn identifier="Version" editable="NO" width="115" minWidth="40" maxWidth="1000" id="h5d-xc-Jih">
                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Version">
@@ -959,7 +967,7 @@ CA
                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
-                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             </tableColumn>
                                             <tableColumn identifier="LatestVersion" editable="NO" width="115" minWidth="40" maxWidth="1000" id="ba4-r8-kgo">
                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Latest Version">
@@ -972,20 +980,7 @@ CA
                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
-                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
-                                            </tableColumn>
-                                            <tableColumn identifier="Status" editable="NO" width="115" minWidth="40" maxWidth="1000" id="JRi-Nr-5hA">
-                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Status">
-                                                    <font key="font" metaFont="smallSystem"/>
-                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                </tableHeaderCell>
-                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="2Ce-cm-oqR">
-                                                    <font key="font" metaFont="system"/>
-                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             </tableColumn>
                                         </tableColumns>
                                         <connections>
@@ -1003,7 +998,7 @@ CA
                                 <autoresizingMask key="autoresizingMask"/>
                             </scroller>
                             <tableHeaderView key="headerView" id="pLZ-e2-9bs">
-                                <rect key="frame" x="0.0" y="0.0" width="517" height="23"/>
+                                <rect key="frame" x="0.0" y="0.0" width="402" height="23"/>
                                 <autoresizingMask key="autoresizingMask"/>
                             </tableHeaderView>
                         </scrollView>

--- a/Cakebrew/Cakebrew-Info.plist
+++ b/Cakebrew/Cakebrew-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>494</string>
+	<string>522</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
A coloured bullet indicating the status of a formula can be easily implemented:

![cakebrew-status-coumn](https://cloud.githubusercontent.com/assets/7220550/13730582/6c637636-e953-11e5-92e8-7368b305f693.png)
I am using a green indicator for an installed up-to-date formula and a yellow one for the outdated formulae.

I had to touch the MainMenu.xib but the different selections from the outline view seem to work still correctly, as for the attached screen capture: [cakebrew-status-cloumn.zip](https://github.com/brunophilipe/Cakebrew/files/171157/cakebrew-status-cloumn.zip).
