### PR TITLE
Fix travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: objective-c
-script: xctool -project Cakebrew.xcodeproj -scheme CakebrewTests test
+script:
+  - xcodebuild -project Cakebrew.xcodeproj -scheme CakebrewTests build test | xcpretty


### PR DESCRIPTION
As [xctool](https://github.com/facebook/xctool) has said, using `xctool` to `build` is deprecated. I change the build script to `xcodebuild`. Now travis build passes.