### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cakebrew was based on a project by [vincentsaluzzo](https://github.com/vincentsa
 
 [Download Now – Version 1.2.3](https://www.cakebrew.com/#download)
 
-Alternatively, [it can be installed via homebrew cask](https://github.com/brunophilipe/Cakebrew/issues/148), with `brew cask install cakebrew`.
+Alternatively, [it can be installed via homebrew cask](https://github.com/brunophilipe/Cakebrew/issues/148), with `brew install cakebrew --cask`.
 
 ## Problems using ZSH?
 


### PR DESCRIPTION
The ```brew cask install cakebrew``` replaced by ```brew install cakebrew --cask``` because the former is [depreciated](https://github.com/Homebrew/discussions/discussions/340). 