### PR TITLE
Fix crash due to the use of NSAlert from non-main Thread

### DIFF
--- a/Cakebrew/BPHomebrewInterface.m
+++ b/Cakebrew/BPHomebrewInterface.m
@@ -160,15 +160,20 @@ static NSString *cakebrewOutputIdentifier = @"+++++Cakebrew+++++";
 	
 	if (!isValidShell)
 	{
-		static NSAlert *alert = nil;
-		if (!alert) {
-			alert = [[NSAlert alloc] init];
-			[alert setMessageText:NSLocalizedString(@"Message_Shell_Invalid_Title", nil)];
-			[alert addButtonWithTitle:NSLocalizedString(@"Generic_OK", nil)];
-			[alert setInformativeText:[NSString stringWithFormat:NSLocalizedString(@"Message_Shell_Invalid_Body", nil), userShell]];
-		}
-		[alert performSelectorOnMainThread:@selector(runModal) withObject:nil waitUntilDone:YES];
-		
+	    static NSAlert *alert = nil;
+	    dispatch_group_t waitForFinish = dispatch_group_create();
+	    dispatch_group_enter(waitForFinish);
+	    dispatch_async(dispatch_get_main_queue(), ^{
+		  if (!alert) {
+			  alert = [[NSAlert alloc] init];
+			  [alert setMessageText:NSLocalizedString(@"Message_Shell_Invalid_Title", nil)];
+			  [alert addButtonWithTitle:NSLocalizedString(@"Generic_OK", nil)];
+			  [alert setInformativeText:[NSString stringWithFormat:NSLocalizedString(@"Message_Shell_Invalid_Body", nil), userShell]];
+		  }
+		  [alert runModal];
+		  dispatch_group_leave(waitForFinish);
+	    });
+	    dispatch_group_wait(waitForFinish, DISPATCH_TIME_FOREVER);
 		NSLog(@"No valid shell found...");
 		return nil;
 	}


### PR DESCRIPTION
The app crashes with the following error:

Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSWindow drag regions should only be invalidated on the Main Thread!'

Reproduced by not having the shell in /etc/shells