### PR TITLE
feat: beautify translations of zh-Hans

### DIFF
--- a/Cakebrew/zh-Hans.lproj/BPBundleWindow.strings
+++ b/Cakebrew/zh-Hans.lproj/BPBundleWindow.strings
@@ -1,24 +1,24 @@
 /* Class = "NSTextFieldCell"; title = "Exporting File"; ObjectID = "Kyw-ca-xgs"; */
-"Kyw-ca-xgs.title" = "Exporting File";
+"Kyw-ca-xgs.title" = "导出文件";
 
 /* Class = "NSTextFieldCell"; title = "Please wait while the file is imported."; ObjectID = "NRz-0t-Pn6"; */
-"NRz-0t-Pn6.title" = "Please wait while the file is imported.";
+"NRz-0t-Pn6.title" = "请等待文件导入完成.";
 
 /* Class = "NSTextFieldCell"; title = "Homebrew Bundle"; ObjectID = "UHp-GH-2qP"; */
 "UHp-GH-2qP.title" = "Homebrew Bundle";
 
 /* Class = "NSTextFieldCell"; title = "Importing File"; ObjectID = "UQX-gO-pze"; */
-"UQX-gO-pze.title" = "Importing File";
+"UQX-gO-pze.title" = "正在导入文件";
 
 /* Class = "NSTextFieldCell"; title = "Please wait while the file is generated."; ObjectID = "Vid-Aa-KXl"; */
-"Vid-Aa-KXl.title" = "Please wait while the file is generated.";
+"Vid-Aa-KXl.title" = "请等待文件生成完成.";
 
 /* Class = "NSWindow"; title = "Window"; ObjectID = "akb-99-UTb"; */
-"akb-99-UTb.title" = "Window";
+"akb-99-UTb.title" = "窗口";
 
 /* Class = "NSTextFieldCell"; title = "Export Successful"; ObjectID = "lO8-qv-x07"; */
-"lO8-qv-x07.title" = "Export Successful";
+"lO8-qv-x07.title" = "导出成功";
 
 /* Class = "NSButtonCell"; title = "Close"; ObjectID = "xSx-yq-DSQ"; */
-"xSx-yq-DSQ.title" = "Close";
+"xSx-yq-DSQ.title" = "关闭";
 

--- a/Cakebrew/zh-Hans.lproj/BPDoctorView.strings
+++ b/Cakebrew/zh-Hans.lproj/BPDoctorView.strings
@@ -2,8 +2,8 @@
 "AlR-6d-ju7.title" = "清除日志";
 
 /* Class = "NSTextFieldCell"; title = "Homebrew Doctor"; ObjectID = "UHp-GH-2qP"; */
-"UHp-GH-2qP.title" = "Homebrew医生";
+"UHp-GH-2qP.title" = "Homebrew 诊断";
 
 /* Class = "NSButtonCell"; title = "Run Doctor"; ObjectID = "YyI-zq-THZ"; */
-"YyI-zq-THZ.title" = "运行医生";
+"YyI-zq-THZ.title" = "运行诊断";
 

--- a/Cakebrew/zh-Hans.lproj/BPFormulaOptionsWindow.strings
+++ b/Cakebrew/zh-Hans.lproj/BPFormulaOptionsWindow.strings
@@ -11,5 +11,5 @@
 "hgj-Zo-s73.title" = "安装";
 
 /* Class = "NSTextFieldCell"; title = "Picking Options for Formula:"; ObjectID = "idS-tT-jie"; */
-"idS-tT-jie.title" = "为Formula选择选项";
+"idS-tT-jie.title" = "为 Formula 选择选项";
 

--- a/Cakebrew/zh-Hans.lproj/BPInstallationWindow.strings
+++ b/Cakebrew/zh-Hans.lproj/BPInstallationWindow.strings
@@ -1,5 +1,5 @@
 /* Class = "NSTextFieldCell"; title = "Uninstalling Formula:"; ObjectID = "P2p-fh-Ixz"; */
-"P2p-fh-Ixz.title" = "卸载Formula";
+"P2p-fh-Ixz.title" = "卸载 Formula";
 
 /* Class = "NSButtonCell"; title = "OK"; ObjectID = "atZ-M7-fU1"; */
 "atZ-M7-fU1.title" = "确定";

--- a/Cakebrew/zh-Hans.lproj/BPSelectedFormula.strings
+++ b/Cakebrew/zh-Hans.lproj/BPSelectedFormula.strings
@@ -2,7 +2,7 @@
 "0oO-wP-SOX.title" = "版本:";
 
 /* Class = "NSTextFieldCell"; title = "Selected Formula Information"; ObjectID = "F2k-Nm-vhK"; */
-"F2k-Nm-vhK.title" = "选中的Formula信息";
+"F2k-Nm-vhK.title" = "选中的 Formula 信息";
 
 /* Class = "NSTextFieldCell"; title = "Location:"; ObjectID = "Vpa-gA-Haq"; */
 "Vpa-gA-Haq.title" = "定位:";

--- a/Cakebrew/zh-Hans.lproj/BPUpdateView.strings
+++ b/Cakebrew/zh-Hans.lproj/BPUpdateView.strings
@@ -2,8 +2,8 @@
 "EE6-5g-Jos.title" = "清除日志:";
 
 /* Class = "NSButtonCell"; title = "Update Homebrew"; ObjectID = "MVF-cn-lfW"; */
-"MVF-cn-lfW.title" = "更新Homebrew";
+"MVF-cn-lfW.title" = "更新 Homebrew";
 
 /* Class = "NSTextFieldCell"; title = "You should update homebrew at least once every 24 hours."; ObjectID = "xJf-gA-oo0"; */
-"xJf-gA-oo0.title" = "你至少要每24小时更新一次homebrew.";
+"xJf-gA-oo0.title" = "你至少要每24小时更新一次 homebrew.";
 

--- a/Cakebrew/zh-Hans.lproj/Localizable.strings
+++ b/Cakebrew/zh-Hans.lproj/Localizable.strings
@@ -2,40 +2,40 @@
 "Cakebrew" = "Cakebrew";
 
 /* No comment provided by engineer. */
-"Confirmation_Install_Formula" = "你确定你想安装'%@'这个formula?";
+"Confirmation_Install_Formula" = "你确定你想安装'%@'这个 formula ?";
 
 /* (No Commment) */
-"Confirmation_Tap_Repo" = "你确定你想tap'%@'这个仓库?";
+"Confirmation_Tap_Repo" = "你确定你想 tap'%@'这个仓库?";
 
 /* No comment provided by engineer. */
-"Confirmation_Uninstall_Formula" = "你确定你想卸载'%@'这个formula?";
+"Confirmation_Uninstall_Formula" = "你确定你想卸载'%@'这个 formula?";
 
 /* (No Commment) */
-"Confirmation_Untap_Repo" = "你确定你想untap'%@'这个仓库?";
+"Confirmation_Untap_Repo" = "你确定你想 untap '%@'这个仓库?";
 
 /* (No Commment) */
-"Confirmation_Update_Formula" = "你确定你想更新选择的formula?";
+"Confirmation_Update_Formula" = "你确定你想更新选择的 formula?";
 
 /* No comment provided by engineer. */
 "Formula_Options_ClickForDetails" = "点击选项查看详情";
 
 /* No comment provided by engineer. */
-"Formula_Options_Confirmation" = "你确定你想安装'%@'这个formula?";
+"Formula_Options_Confirmation" = "你确定你想安装'%@'这个 formula?";
 
 /* No comment provided by engineer. */
-"Formula_Options_NoOptions" = "这个formula没有可用的安装选项.";
+"Formula_Options_NoOptions" = "这个 formula 没有可用的安装选项.";
 
 /* No comment provided by engineer. */
-"Formula_Options_VoiceOver" = "Formula选项";
+"Formula_Options_VoiceOver" = "Formula 选项";
 
 /* No comment provided by engineer. */
-"Formula_Options_VoiceOver_Description" = "在Formula选项表里为每一行选项描述提供了VoiceOver帮助.";
+"Formula_Options_VoiceOver_Description" = "在 Formula 选项表里为每一行选项描述提供了 VoiceOver 帮助.";
 
 /* (No Commment) */
-"Formula_Popover_Error" = "检索Formula信息出错";
+"Formula_Popover_Error" = "检索 Formula 信息出错";
 
 /* No comment provided by engineer. */
-"Formula_Popover_Title" = "Formula的信息: %@";
+"Formula_Popover_Title" = "Formula 的信息: %@";
 
 /* No comment provided by engineer. */
 "Formula_Status_Installed" = "已安装";
@@ -68,7 +68,7 @@
 "Generic_Yes" = "是";
 
 /* No comment provided by engineer. */
-"Homebrew_AppNap_Task_Reason" = "Homebrew任务运行中";
+"Homebrew_AppNap_Task_Reason" = "Homebrew 任务运行中";
 
 /* No comment provided by engineer. */
 "Homebrew_Task_Finished" = "任务完成";
@@ -77,61 +77,61 @@
 "Homebrew_Task_Finished_At" = "at";
 
 /* No comment provided by engineer. */
-"Info_View_Formula_No_Conflicts" = "这个formula目前没有冲突.";
+"Info_View_Formula_No_Conflicts" = "这个 formula 目前没有冲突.";
 
 /* No comment provided by engineer. */
-"Info_View_Formula_No_Dependencies" = "这个formula没有依赖!";
+"Info_View_Formula_No_Dependencies" = "这个 formula 没有依赖!";
 
 /* No comment provided by engineer. */
 "Info_View_Formula_No_Description" = "没有提供描述.";
 
 /* No comment provided by engineer. */
-"Info_View_Formula_Not_Installed" = "Formula未安装.";
+"Info_View_Formula_Not_Installed" = "Formula 未安装.";
 
 /* No comment provided by engineer. */
 "Info_View_Multiple_Values" = "多值";
 
 /* No comment provided by engineer. */
-"Installation_Window_All_Formulae" = "所有过期的Formulae";
+"Installation_Window_All_Formulae" = "所有过期的 Formulae";
 
 /* No comment provided by engineer. */
 "Installation_Window_Operation_Cleanup" = "清理运行中…";
 
 /* No comment provided by engineer. */
-"Installation_Window_Operation_Install" = "Formula安装中:";
+"Installation_Window_Operation_Install" = "Formula 安装中:";
 
 /* No comment provided by engineer. */
 "Installation_Window_Operation_Tap" = "Tapping Repo:";
 
 /* No comment provided by engineer. */
-"Installation_Window_Operation_Uninstall" = "Formula卸载中:";
+"Installation_Window_Operation_Uninstall" = "Formula 卸载中:";
 
 /* No comment provided by engineer. */
 "Installation_Window_Operation_Untap" = "Untapping Repo:";
 
 /* No comment provided by engineer. */
-"Installation_Window_Operation_Update" = "Formulae更新中:";
+"Installation_Window_Operation_Update" = "Formulae 更新中:";
 
 /* No comment provided by engineer. */
-"Message_BGTask_Body" = "对不起，后台任务已在运行。您不能同时执行两个任务。";
+"Message_BGTask_Body" = "对不起，后台任务已在运行。您不能同时执行两个任务.";
 
 /* No comment provided by engineer. */
 "Message_BGTask_Title" = "激活后台任务!";
 
 /* No comment provided by engineer. */
-"Message_No_Homebrew_Body" = "Homebrew没有在你的系统中找到。请在使用Cakebrew之前安装Homebrew。您可以点击下面的按钮来打开自制的网站。";
+"Message_No_Homebrew_Body" = "Homebrew没有在你的系统中找到。请在使用 Cakebrew 之前安装 Homebrew。您可以点击下面的按钮来打开 Homebrew 官网.";
 
 /* No comment provided by engineer. */
 "Message_No_Homebrew_Title" = "Homebrew网站";
 
 /* No comment provided by engineer. */
-"Message_Shell_Invalid_Body" = "请在重试前增加你的shell\"%@\"到在\"/etc/shells\"的有效shell文件";
+"Message_Shell_Invalid_Body" = "请在重试前把你的 shell \"%@\" 添加到 \"/etc/shells\" 文件中.";
 
 /* No comment provided by engineer. */
-"Message_Shell_Invalid_Title" = "没有找到有效的shell!";
+"Message_Shell_Invalid_Title" = "没有找到有效的 shell!";
 
 /* No comment provided by engineer. */
-"Message_Tap_Body" = "What repository would you like to tap?";
+"Message_Tap_Body" = "你希望 tap 哪个 repository would you like to tap?";
 
 /* No comment provided by engineer. */
 "Message_Tap_Title" = "Tapping Repository";
@@ -143,16 +143,16 @@
 "Message_Untap_Title" = "Untapping Repository";
 
 /* No comment provided by engineer. */
-"Message_Update_All_Outdated_Body" = "你确定想更新所有过期的formulae?";
+"Message_Update_All_Outdated_Body" = "你确定想更新所有过期的 formulae?";
 
 /* No comment provided by engineer. */
-"Message_Update_All_Outdated_Title" = "更新所有过期的formulae";
+"Message_Update_All_Outdated_Title" = "更新所有过期的 formulae";
 
 /* No comment provided by engineer. */
-"Message_Update_Formulae_Body" = "你确定想更新这些formulae: '%@'?";
+"Message_Update_Formulae_Body" = "你确定想更新这些 formulae: '%@'?";
 
 /* No comment provided by engineer. */
-"Message_Update_Formulae_Title" = "Formulae更新中";
+"Message_Update_Formulae_Title" = "Formulae 更新中";
 
 /* No comment provided by engineer. */
 "Sidebar_Group_Formulae" = "Formulae";
@@ -161,19 +161,19 @@
 "Sidebar_Group_Tools" = "工具";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_All" = "这是所有Homebrew可供安装的formulae.";
+"Sidebar_Info_All" = "这是所有 Homebrew 可供安装的 formulae.";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_Doctor" = "医生是一个Homebrew检测引起错误最常见的原因的功能.";
+"Sidebar_Info_Doctor" = "诊断是一个 Homebrew 功能，可以检测最常见的错误原因.";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_Installed" = "这些formulae已经安装在你的系统中.";
+"Sidebar_Info_Installed" = "这些 formulae 已经安装在你的系统中.";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_Leaves" = "这些formulae没有依赖其他的formulae.";
+"Sidebar_Info_Leaves" = "这些 formulae 没有依赖其他的 formulae.";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_Outdated" = "这些formulae已经安装，但有一个可用的更新.";
+"Sidebar_Info_Outdated" = "这些 formulae 已经安装，但有一个可用的更新.";
 
 /* No comment provided by engineer. */
 "Sidebar_Info_Repos" = "These are the repositories you have tapped.";
@@ -182,19 +182,19 @@
 "Sidebar_Info_SearchResults" = "下面是你搜索的结果";
 
 /* No comment provided by engineer. */
-"Sidebar_Info_Update" = "更新Homebrew标书拉取最新的可用formulae信息";
+"Sidebar_Info_Update" = "拉取最新的可用 formulae 信息";
 
 /* No comment provided by engineer. */
-"Sidebar_Item_All" = "全部Formulae";
+"Sidebar_Item_All" = "全部 Formulae";
 
 /* No comment provided by engineer. */
-"Sidebar_Item_Doctor" = "医生";
+"Sidebar_Item_Doctor" = "诊断";
 
 /* No comment provided by engineer. */
 "Sidebar_Item_Installed" = "已安装";
 
 /* No comment provided by engineer. */
-"Sidebar_Item_Leaves" = "树叶";
+"Sidebar_Item_Leaves" = "Leaves";
 
 /* No comment provided by engineer. */
 "Sidebar_Item_Outdated" = "过期";
@@ -209,10 +209,10 @@
 "Sidebar_VoiceOver_Tools" = "工具";
 
 /* No comment provided by engineer. */
-"Toolbar_Homebrew_Update" = "更新Homebrew";
+"Toolbar_Homebrew_Update" = "更新 Homebrew";
 
 /* No comment provided by engineer. */
-"Toolbar_Install_Formula" = "安装Formula";
+"Toolbar_Install_Formula" = "安装 Formula";
 
 /* No comment provided by engineer. */
 "Toolbar_More_Information" = "更多信息";
@@ -224,13 +224,13 @@
 "Toolbar_Tap_Repo" = "Tap Repository";
 
 /* No comment provided by engineer. */
-"Toolbar_Uninstall_Formula" = "卸载Formula";
+"Toolbar_Uninstall_Formula" = "卸载 Formula";
 
 /* No comment provided by engineer. */
 "Toolbar_Untap_Repo" = "Untap Repository";
 
 /* No comment provided by engineer. */
-"Toolbar_Update_Formula" = "更新Formula";
+"Toolbar_Update_Formula" = "更新 Formula";
 
 /* No comment provided by engineer. */
 "Toolbar_Update_Selected" = "更新所选";

--- a/Cakebrew/zh-Hans.lproj/MainMenu.strings
+++ b/Cakebrew/zh-Hans.lproj/MainMenu.strings
@@ -11,7 +11,7 @@
 "3xE-6a-fkA.title" = "未选择";
 
 /* Class = "NSMenuItem"; title = "Update Formula"; ObjectID = "4ab-Ns-Wry"; */
-"4ab-Ns-Wry.title" = "更新Formula";
+"4ab-Ns-Wry.title" = "更新 Formula";
 
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "前置全部窗口";
@@ -26,13 +26,13 @@
 "8Vh-lk-gYe.title" = "更新";
 
 /* Class = "NSMenuItem"; title = "Installed Formulae"; ObjectID = "8gP-gb-YtQ"; */
-"8gP-gb-YtQ.title" = "已安装的Formulae";
+"8gP-gb-YtQ.title" = "已安装的 Formulae";
 
 /* Class = "NSMenu"; title = "Find"; ObjectID = "8wr-BZ-YYu"; */
 "8wr-BZ-YYu.title" = "查找";
 
 /* Class = "NSMenuItem"; title = "Formula Website"; ObjectID = "9Fv-tF-1qy"; */
-"9Fv-tF-1qy.title" = "Formula网站";
+"9Fv-tF-1qy.title" = "Formula 网站";
 
 /* Class = "NSMenuItem"; title = "Edit"; ObjectID = "9Xg-s6-Icq"; */
 "9Xg-s6-Icq.title" = "编辑";
@@ -56,7 +56,7 @@
 "57.title" = "Cakebrew";
 
 /* Class = "NSMenuItem"; title = "About Cakebrew"; ObjectID = "58"; */
-"58.title" = "关于Cakebrew";
+"58.title" = "关于 Cakebrew";
 
 /* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "129"; */
 "129.title" = "偏好设置…";
@@ -68,10 +68,10 @@
 "131.title" = "服务";
 
 /* Class = "NSMenuItem"; title = "Hide Cakebrew"; ObjectID = "134"; */
-"134.title" = "隐藏Cakebrew";
+"134.title" = "隐藏 Cakebrew";
 
 /* Class = "NSMenuItem"; title = "Quit Cakebrew"; ObjectID = "136"; */
-"136.title" = "退出Cakebrew";
+"136.title" = "退出 Cakebrew";
 
 /* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "145"; */
 "145.title" = "隐藏其他";
@@ -92,7 +92,7 @@
 "491.title" = "帮助";
 
 /* Class = "NSMenuItem"; title = "Cakebrew Help"; ObjectID = "492"; */
-"492.title" = "Cakebrew帮助";
+"492.title" = "Cakebrew 帮助";
 
 /* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "A78-TI-Q8X"; */
 "A78-TI-Q8X.headerCell.title" = "名字";
@@ -110,19 +110,19 @@
 "DNi-yY-5Ha.title" = "查找所选内容";
 
 /* Class = "NSMenuItem"; title = "Upgrade All Formulae"; ObjectID = "DdP-fd-ccO"; */
-"DdP-fd-ccO.title" = "升级全部Formulae";
+"DdP-fd-ccO.title" = "升级全部 Formulae";
 
 /* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "Dki-FU-69n"; */
 "Dki-FU-69n.title" = "替换";
 
 /* Class = "NSMenuItem"; title = "Search for Formula"; ObjectID = "DpP-yi-xdi"; */
-"DpP-yi-xdi.title" = "搜索Formula";
+"DpP-yi-xdi.title" = "搜索 Formula";
 
 /* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "EBJ-Ce-8OO"; */
 "EBJ-Ce-8OO.title" = "开始朗读";
 
 /* Class = "NSMenuItem"; title = "Upgrade Selected Formulae"; ObjectID = "Ep8-j6-m5Q"; */
-"Ep8-j6-m5Q.title" = "升级选中Formulae";
+"Ep8-j6-m5Q.title" = "升级选中 Formulae";
 
 /* Class = "NSMenu"; title = "Speech"; ObjectID = "Eud-wi-dvG"; */
 "Eud-wi-dvG.title" = "语音";
@@ -134,7 +134,7 @@
 "H1C-ip-FlF.title" = "撤销";
 
 /* Class = "NSMenuItem"; title = "Update Formula"; ObjectID = "Hhd-b7-GOc"; */
-"Hhd-b7-GOc.title" = "更新Formula";
+"Hhd-b7-GOc.title" = "更新 Formula";
 
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "J92-AZ-XUi"; */
 "J92-AZ-XUi.title" = "重做";
@@ -146,16 +146,16 @@
 "JRi-Nr-5hA.headerCell.title" = "状态";
 
 /* Class = "NSMenuItem"; title = "Outdated Formulae"; ObjectID = "KUc-5l-twA"; */
-"KUc-5l-twA.title" = "过期的Formulae";
+"KUc-5l-twA.title" = "过期的 Formulae";
 
 /* Class = "NSMenu"; title = "Edit"; ObjectID = "LYP-iZ-WcV"; */
 "LYP-iZ-WcV.title" = "编辑";
 
 /* Class = "NSMenuItem"; title = "Install Formula"; ObjectID = "Lcb-tm-ATo"; */
-"Lcb-tm-ATo.title" = "安装Formula";
+"Lcb-tm-ATo.title" = "安装 Formula";
 
 /* Class = "NSMenuItem"; title = "Leaves"; ObjectID = "M9N-PI-gBO"; */
-"M9N-PI-gBO.title" = "树叶";
+"M9N-PI-gBO.title" = "Leaves";
 
 /* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "MQL-Vg-ECI"; */
 "MQL-Vg-ECI.title" = "显示替换";
@@ -173,13 +173,13 @@
 "NrN-pe-J7E.title" = "停止朗读";
 
 /* Class = "NSMenuItem"; title = "Brew Cleanup…"; ObjectID = "OKR-gG-lsa"; */
-"OKR-gG-lsa.title" = "Brew清理中…";
+"OKR-gG-lsa.title" = "Brew 清理中…";
 
 /* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "OSn-ju-y85"; */
 "OSn-ju-y85.title" = "查找与替换…";
 
 /* Class = "NSMenuItem"; title = "Uninstall Formula"; ObjectID = "Tzv-5t-RhL"; */
-"Tzv-5t-RhL.title" = "卸载Formula";
+"Tzv-5t-RhL.title" = "卸载 Formula";
 
 /* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "UOm-zM-WGz"; */
 "UOm-zM-WGz.title" = "键入时检查拼写";
@@ -194,7 +194,7 @@
 "Vio-Nc-WTc.title" = "Install Formula with Options...";
 
 /* Class = "NSTabViewItem"; label = "Doctor"; ObjectID = "WM9-6z-Jzl"; */
-"WM9-6z-Jzl.label" = "医生";
+"WM9-6z-Jzl.label" = "诊断";
 
 /* Class = "NSMenu"; title = "Spelling"; ObjectID = "X7p-5G-5Dv"; */
 "X7p-5G-5Dv.title" = "拼写";
@@ -251,7 +251,7 @@
 "eus-Jb-JjS.title" = "更多信息";
 
 /* Class = "NSMenuItem"; title = "Install Formula"; ObjectID = "fhF-VX-squ"; */
-"fhF-VX-squ.title" = "安装Formula";
+"fhF-VX-squ.title" = "安装 Formula";
 
 /* Class = "NSMenuItem"; title = "More Information"; ObjectID = "gxx-2S-F5T"; */
 "gxx-2S-F5T.title" = "更多信息";
@@ -263,7 +263,7 @@
 "h5d-xc-Jih.headerCell.title" = "版本";
 
 /* Class = "NSMenuItem"; title = "Uninstall Formula"; ObjectID = "i3A-Nx-qPJ"; */
-"i3A-Nx-qPJ.title" = "卸载Formula";
+"i3A-Nx-qPJ.title" = "卸载 Formula";
 
 /* Class = "NSMenu"; title = "Tools"; ObjectID = "lOM-6G-bAo"; */
 "lOM-6G-bAo.title" = "工具";
@@ -299,5 +299,5 @@
 "yL4-oW-nIm.label" = "更新";
 
 /* Class = "NSMenuItem"; title = "All Formulae"; ObjectID = "zam-2s-isx"; */
-"zam-2s-isx.title" = "全部Formulae";
+"zam-2s-isx.title" = "全部 Formulae";
 


### PR DESCRIPTION
* Beautify translations of zh-Hans.
* Use english punctuations.
* Add an extra whitespace between english letters and mandarin words.
* Do not translate `Leaves` to `树叶`, nobody knows what is `树叶`.
* Translate `Doctor` to `诊断`.  `医生` is oddly.