### PR TITLE
Renamed OS X to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cakebrew
 
-The Homebrew GUI App for OS X
+The Homebrew GUI App for macOS
 
 [![Build Status](https://travis-ci.org/brunophilipe/Cakebrew.svg?branch=dev)](https://travis-ci.org/brunophilipe/Cakebrew)
 


### PR DESCRIPTION
## Summary

- Updates the README tagline from “OS X” to “macOS” to match Apple’s current platform branding.
- Keeps the project description accurate for current macOS versions.
- Addresses the terminology request from #258.

## Changes

- Replaces `The Homebrew GUI App for OS X` with `The Homebrew GUI App for macOS` in `README.md`.

## Testing

- Not run; documentation-only change.

Fixes #258